### PR TITLE
fix(paths): add os specific directory handling for windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -130,11 +130,16 @@ fn handle_main_command(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     args: Args,
 ) -> Result<()> {
-    let config_file_path = dirs::home_dir()
-        .context("Unable to get home directory")?
-        .join(".config")
-        .join("donkeytype")
-        .join("donkeytype-config.json");
+    let config_file_path = if cfg!(target_os = "windows") {
+        dirs::config_local_dir().context("Unable to get local config directory")?
+    } else {
+        dirs::home_dir()
+            .context("Unable to get home directory")?
+            .join(".config")
+    }
+    .join("donkeytype")
+    .join("donkeytype-config.json");
+
     let config = Config::new(args, config_file_path).context("Unable to create config")?;
     let expected_input = ExpectedInput::new(&config).context("Unable to create expected input")?;
 
@@ -234,11 +239,15 @@ mod tests {
     }
 
     fn setup_terminal(args: Args) -> Result<(Config, ExpectedInput, Terminal<TestBackend>)> {
-        let config_file_path = dirs::home_dir()
-            .context("Unable to get home directory")?
-            .join(".config")
-            .join("donkeytype")
-            .join("donkeytype-config.json");
+        let config_file_path = if cfg!(target_os = "windows") {
+            dirs::config_local_dir().context("Unable to get local config directory")?
+        } else {
+            dirs::home_dir()
+                .context("Unable to get home directory")?
+                .join(".config")
+        }
+        .join("donkeytype")
+        .join("donkeytype-config.json");
 
         let config = Config::new(args, config_file_path).context("Unable to create config")?;
         let expected_input =

--- a/src/test_results.rs
+++ b/src/test_results.rs
@@ -404,11 +404,15 @@ fn render_chart(
 }
 
 fn get_results_dir_path() -> Result<PathBuf> {
-    let dir_path = dirs::home_dir()
-        .context("Unable to get home directory")?
-        .join(".local")
-        .join("share")
-        .join("donkeytype");
+    let dir_path = if cfg!(target_os = "windows") {
+        dirs::config_local_dir().context("Unable to get local config directory")?
+    } else {
+        dirs::home_dir()
+            .context("Unable to get home directory")?
+            .join(".local")
+            .join("share")
+    }
+    .join("donkeytype");
 
     Ok(dir_path)
 }


### PR DESCRIPTION
Adjusted the path generation in `get_results_dir_path`, `handle_main_command`, and `setup_terminal` functions to account for Windows-specific local config directory conventions using the `cfg!` macro.

This PR closes issue https://github.com/radlinskii/donkeytype/issues/37. 

Below are paths for both the config & results files by OS.

### Config file:

**Windows:** `C:\Users\{Username}\AppData\Local\donkeytype\donkeytype-config.json`
**Linux:** `/home/{Username}/.config/donkeytype/donkeytype-config.json`
**MacOS:** `/Users/{Username}/.config/donkeytype/donkeytype-config.json`

### Results file:

**Windows:** `C:\Users\{Username}\AppData\Local\donkeytype\donkeytype-results.csv`
**Linux:** `/home/{Username}/.local/share/donkeytype/donkeytype-results.csv`
**MacOS:** `/Users/{Username}/.local/share/donkeytype/donkeytype-results.csv`

