### PR TITLE
fix: windows double keypress issue

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - target: x86_64-pc-windows-gnu
-          #  archive: zip
+          - target: x86_64-pc-windows-gnu
+            archive: zip
           # - target: x86_64-unknown-linux-musl
           #  archive: tar.gz tar.xz tar.zst
           - target: x86_64-apple-darwin

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,11 +130,16 @@ fn handle_main_command(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     args: Args,
 ) -> Result<()> {
-    let config_file_path = dirs::home_dir()
-        .context("Unable to get home directory")?
-        .join(".config")
-        .join("donkeytype")
-        .join("donkeytype-config.json");
+    let config_file_path = if cfg!(target_os = "windows") {
+        dirs::config_local_dir().context("Unable to get local config directory")?
+    } else {
+        dirs::home_dir()
+            .context("Unable to get home directory")?
+            .join(".config")
+    }
+    .join("donkeytype")
+    .join("donkeytype-config.json");
+
     let config = Config::new(args, config_file_path).context("Unable to create config")?;
     let expected_input = ExpectedInput::new(&config).context("Unable to create expected input")?;
 
@@ -234,11 +239,15 @@ mod tests {
     }
 
     fn setup_terminal(args: Args) -> Result<(Config, ExpectedInput, Terminal<TestBackend>)> {
-        let config_file_path = dirs::home_dir()
-            .context("Unable to get home directory")?
-            .join(".config")
-            .join("donkeytype")
-            .join("donkeytype-config.json");
+        let config_file_path = if cfg!(target_os = "windows") {
+            dirs::config_local_dir().context("Unable to get local config directory")?
+        } else {
+            dirs::home_dir()
+                .context("Unable to get home directory")?
+                .join(".config")
+        }
+        .join("donkeytype")
+        .join("donkeytype-config.json");
 
         let config = Config::new(args, config_file_path).context("Unable to create config")?;
         let expected_input =

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,7 +12,7 @@
 //! And test statistics are returned from the runner.
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode, KeyModifiers, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use mockall::automock;
 use std::time::{Duration, Instant};
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -12,7 +12,7 @@
 //! And test statistics are returned from the runner.
 
 use anyhow::{Context, Result};
-use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::event::{self, Event, KeyCode, KeyModifiers, KeyEventKind};
 use mockall::automock;
 use std::time::{Duration, Instant};
 
@@ -106,68 +106,70 @@ impl Runner {
 
             if event::poll(timeout).context("Unable to poll for event")? {
                 if let Event::Key(key) = event::read().context("Unable to read event")? {
-                    match self.input_mode {
-                        InputMode::Normal => match key.code {
-                            KeyCode::Char('e') => {
-                                start_time = if is_started {
-                                    start_time + pause_time.elapsed()
-                                } else {
-                                    Instant::now()
-                                };
-                                is_started = true;
-                                self.input_mode = InputMode::Editing;
-                            }
-                            KeyCode::Char('q') => {
-                                // todo return canceled test error and handle it in main
-                                return Ok(TestResults::new(
-                                    Stats::default(),
-                                    self.config.clone(),
-                                    false,
-                                ));
-                            }
-                            _ => {}
-                        },
-                        InputMode::Editing => match key.code {
-                            // Crossterm returns `ctrl+w` or ``ctrl+h` when `ctrl+backspace` is pressed
-                            // see: https://github.com/crossterm-rs/crossterm/issues/504
-                            KeyCode::Char('h') | KeyCode::Char('w')
-                                if key.modifiers.contains(KeyModifiers::CONTROL) =>
-                            {
-                                self.remove_last_word();
-                            }
-                            KeyCode::Char(c) => {
-                                self.input.push(c);
-
-                                let expected_input = self
-                                    .expected_input
-                                    .get_string(self.input.len())
-                                    .chars()
-                                    .collect::<Vec<char>>();
-
-                                let is_correct =
-                                    self.input.chars().last() == expected_input.last().copied();
-
-                                if !is_correct {
-                                    self.raw_mistakes_count += 1;
-                                } else {
-                                    self.raw_valid_characters_count += 1;
+                    if key.kind == KeyEventKind::Press {
+                        match self.input_mode {
+                            InputMode::Normal => match key.code {
+                                KeyCode::Char('e') => {
+                                    start_time = if is_started {
+                                        start_time + pause_time.elapsed()
+                                    } else {
+                                        Instant::now()
+                                    };
+                                    is_started = true;
+                                    self.input_mode = InputMode::Editing;
                                 }
-                            }
-                            KeyCode::Backspace
-                                if key.modifiers.contains(KeyModifiers::ALT)
-                                    | key.modifiers.contains(KeyModifiers::CONTROL) =>
-                            {
-                                self.remove_last_word();
-                            }
-                            KeyCode::Backspace => {
-                                self.input.pop();
-                            }
-                            KeyCode::Esc => {
-                                pause_time = Instant::now();
-                                self.input_mode = InputMode::Normal;
-                            }
-                            _ => {}
-                        },
+                                KeyCode::Char('q') => {
+                                    // todo return canceled test error and handle it in main
+                                    return Ok(TestResults::new(
+                                        Stats::default(),
+                                        self.config.clone(),
+                                        false,
+                                    ));
+                                }
+                                _ => {}
+                            },
+                            InputMode::Editing => match key.code {
+                                // Crossterm returns `ctrl+w` or ``ctrl+h` when `ctrl+backspace` is pressed
+                                // see: https://github.com/crossterm-rs/crossterm/issues/504
+                                KeyCode::Char('h') | KeyCode::Char('w')
+                                    if key.modifiers.contains(KeyModifiers::CONTROL) =>
+                                {
+                                    self.remove_last_word();
+                                }
+                                KeyCode::Char(c) => {
+                                    self.input.push(c);
+
+                                    let expected_input = self
+                                        .expected_input
+                                        .get_string(self.input.len())
+                                        .chars()
+                                        .collect::<Vec<char>>();
+
+                                    let is_correct =
+                                        self.input.chars().last() == expected_input.last().copied();
+
+                                    if !is_correct {
+                                        self.raw_mistakes_count += 1;
+                                    } else {
+                                        self.raw_valid_characters_count += 1;
+                                    }
+                                }
+                                KeyCode::Backspace
+                                    if key.modifiers.contains(KeyModifiers::ALT)
+                                        | key.modifiers.contains(KeyModifiers::CONTROL) =>
+                                {
+                                    self.remove_last_word();
+                                }
+                                KeyCode::Backspace => {
+                                    self.input.pop();
+                                }
+                                KeyCode::Esc => {
+                                    pause_time = Instant::now();
+                                    self.input_mode = InputMode::Normal;
+                                }
+                                _ => {}
+                            },
+                        }
                     }
                 }
             }

--- a/src/test_results.rs
+++ b/src/test_results.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Datelike, Local, Timelike};
-use crossterm::event::{self, Event, KeyCode};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::{
     prelude::{Backend, Constraint, Direction, Layout, Rect},
     style::{Style, Stylize},
@@ -196,11 +196,13 @@ impl TestResults {
 
             if event::poll(Duration::from_millis(100)).context("Unable to poll for event")? {
                 if let Event::Key(key) = event::read().context("Unable to read event")? {
-                    match key.code {
-                        KeyCode::Esc => {
-                            break;
+                    if key.kind == KeyEventKind::Press {
+                        match key.code {
+                            KeyCode::Esc => {
+                                break;
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
             }
@@ -313,11 +315,13 @@ pub fn render_results<B: Backend>(
 
         if event::poll(Duration::from_millis(100)).context("Unable to poll for event")? {
             if let Event::Key(key) = event::read().context("Unable to read event")? {
-                match key.code {
-                    KeyCode::Esc => {
-                        break;
+                if key.kind == KeyEventKind::Press {
+                    match key.code {
+                        KeyCode::Esc => {
+                            break;
+                        }
+                        _ => {}
                     }
-                    _ => {}
                 }
             }
         }

--- a/src/test_results.rs
+++ b/src/test_results.rs
@@ -404,11 +404,15 @@ fn render_chart(
 }
 
 fn get_results_dir_path() -> Result<PathBuf> {
-    let dir_path = dirs::home_dir()
-        .context("Unable to get home directory")?
-        .join(".local")
-        .join("share")
-        .join("donkeytype");
+    let dir_path = if cfg!(target_os = "windows") {
+        dirs::config_local_dir().context("Unable to get local config directory")?
+    } else {
+        dirs::home_dir()
+            .context("Unable to get home directory")?
+            .join(".local")
+            .join("share")
+    }
+    .join("donkeytype");
 
     Ok(dir_path)
 }


### PR DESCRIPTION
- Addressed a bug on Windows where each key press event is registered twice. A fix has been implemented by checking for `KeyEventKind::Press` before processing the key press.
- Added a Windows-GNU target to the release

This PR closes issue #39 and #37.

```
Test result: ok. 20 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
```