### PR TITLE
add Linux build support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         include:
           - target: x86_64-pc-windows-gnu
             archive: zip
-          # - target: x86_64-unknown-linux-musl
-          #  archive: tar.gz tar.xz tar.zst
+          - target: x86_64-unknown-linux-musl
+            archive: tar.gz tar.xz tar.zst
           - target: x86_64-apple-darwin
             archive: zip
     steps:


### PR DESCRIPTION
This will resolve #36. I've tested it on my Ubuntu machine, and all of the functionality seems to work properly on the Linux system. Following on the comments by [@NaiveInvestigator](https://github.com/radlinskii/donkeytype/issues/36#issuecomment-1776606653), this seems to work on Fedora as well.