### PR TITLE
added custom results_path argument #47

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -43,6 +43,10 @@ pub struct Args {
     #[arg(long)]
     pub save_results: Option<bool>,
 
+    /// path to save the test results, enabled only when save_results is true
+    #[arg(long, requires = "save_results")]
+    pub results_path: Option<String>,
+
     /// Add subcommands here
     #[command(subcommand)]
     pub history: Option<SubCommand>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,6 +72,7 @@ pub struct Config {
     pub uppercase_ratio: f64,
     pub colors: ColorScheme,
     pub save_results: bool,
+    pub results_path: Option<PathBuf>,
 }
 
 /// Used by `serde` crate to parse config file into a rust struct
@@ -87,6 +88,7 @@ struct ConfigFile {
     pub uppercase_ratio: Option<f64>,
     pub colors: Option<ConfigFileColorScheme>,
     pub save_results: Option<bool>,
+    pub results_path: Option<String>,
 }
 
 /// Struct used be `serde` crate to parse colors config from config file
@@ -113,6 +115,7 @@ impl Config {
             uppercase_ratio: 0.15,
             colors: ColorScheme::default(),
             save_results: true,
+            results_path: None,
         }
     }
 
@@ -210,6 +213,12 @@ fn augment_config_with_config_file(config: &mut Config, mut config_file: fs::Fil
         if let Some(save_results) = config_from_file.save_results {
             config.save_results = save_results;
         }
+
+        if let Some(true) = config_from_file.save_results {
+            if let Some(path) = config_from_file.results_path {
+                config.results_path = Some(PathBuf::from(path));
+            }
+        }
     }
 
     Ok(())
@@ -259,6 +268,12 @@ fn augment_config_with_args(config: &mut Config, args: Args) {
     if let Some(save_results_flag) = args.save_results {
         config.save_results = save_results_flag;
     }
+
+    if let Some(true) = args.save_results {
+        if let Some(path) = args.results_path {
+            config.results_path = Some(PathBuf::from(path));
+        }
+    }
 }
 
 #[cfg(test)]
@@ -288,6 +303,7 @@ mod tests {
             uppercase: None,
             uppercase_ratio: None,
             save_results: None,
+            results_path: None,
             history: None,
         };
         let config = Config::new(args, PathBuf::new()).expect("Unable to create config");
@@ -314,6 +330,7 @@ mod tests {
             uppercase: None,
             uppercase_ratio: None,
             save_results: None,
+            results_path: None,
             history: None,
         };
         let config =
@@ -336,6 +353,7 @@ mod tests {
             uppercase: None,
             uppercase_ratio: None,
             save_results: Some(false),
+            results_path: None,
             history: None,
         };
         let config = Config::new(args, PathBuf::new()).expect("Unable to create config");
@@ -363,6 +381,7 @@ mod tests {
             uppercase: None,
             uppercase_ratio: None,
             save_results: Some(true),
+            results_path: Some(String::from("/some-path")),
             history: None,
         };
         let config =
@@ -376,5 +395,6 @@ mod tests {
             Some(PathBuf::from("/etc/dict/words"))
         );
         assert_eq!(config.save_results, true);
+        assert_eq!(config.results_path, Some(PathBuf::from("/some-path")));
     }
 }

--- a/src/expected_input.rs
+++ b/src/expected_input.rs
@@ -150,6 +150,7 @@ mod tests {
             uppercase_ratio: 0.45,
             colors: ColorScheme::default(),
             save_results: false,
+            results_path: None,
         };
 
         let expected_input = ExpectedInput::new(&config).expect("unable to create expected input");

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,6 +276,7 @@ mod tests {
             symbols: None,
             symbols_ratio: None,
             save_results: None,
+            results_path: None,
             history: None,
         };
 
@@ -312,6 +313,7 @@ mod tests {
             symbols: None,
             symbols_ratio: None,
             save_results: None,
+            results_path: None,
             history: None,
         };
 

--- a/src/test_results.rs
+++ b/src/test_results.rs
@@ -48,6 +48,7 @@ pub struct TestResults {
     pub dictionary_path: Option<String>,
     pub uppercase: Option<bool>,
     pub uppercase_ratio: Option<f64>,
+    pub results_path: Option<PathBuf>,
 
     // tells if test was successfully completed and results should be displayed and saved.
     #[serde(skip)]
@@ -120,13 +121,18 @@ impl TestResults {
 
             completed,
             save: config.save_results,
+            results_path: config.results_path,
         }
     }
 
     /// saves test statistics and configuration to a file in users home directory
     pub fn save_to_file(&self) -> Result<(), anyhow::Error> {
-        let results_file_path =
+        let default_results_path =
             get_results_file_path().context("Unable to ge results file path")?;
+        let results_file_path = match &self.results_path {
+            Some(results_path) => results_path,
+            None => &default_results_path,
+        };
 
         let results = read_previous_results().context("Unable to read previous results")?;
 


### PR DESCRIPTION
Added a custom --results-path argument with the following logic:

1. --results-path only works when --save-results is set to true
2. Results will be saved at the location specified by --results-path